### PR TITLE
docker imageの整理

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.10.8-slim
+FROM python3.10.8_with_mecab:latest
 
-COPY ./img_setup.sh /img_setup.sh
 COPY ./Pipfile.lock /Pipfile.lock
 COPY ./app /app
-COPY ./dic /dic
 COPY ./.env /.env
 
-RUN ["/img_setup.sh"]
+RUN pip install --upgrade pip \
+    && pip install pipenv \
+    && pipenv sync
 
 EXPOSE 8000
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,31 +1,10 @@
 #!bin/bash
-# mecabの確認・辞書をカレントディレクトリにコピー
-if [ -z "$(echo `mecab-config`)" ]; then
-    echo "mecabなどが入っていないのでインストールしてください"
-    exit 0
-fi
-MECAB_DIC_PATH=$(echo `mecab-config --dicdir`"/mecab-ipadic-neologd")
-
-if [ -z "$(ls ${MECAB_DIC_PATH}/)" ]; then
-    echo "ipadic-neologd辞書がありませんインストールしてください"
-    exit 0
-else
-    if [ ! -d ./dic ]; then
-        mkdir dic
-    fi
-    if [ -z "$(ls ./dic)" ]; then
-        cp -r ${MECAB_DIC_PATH} ./dic
-    fi
-fi
-# 環境変数設定
-touch .env
-if [ -z "grep MECAB_DIC_PATH .env" ]; then
-    echo "MECAB_DIC_PATH=/dic/mecab-ipadic-neologd" >> .env
-fi
 
 # docker build & run
-docker build -t deployimg .
-if [ -n "$(echo `docker ps -a | grep deployimg`)" ]; then
-    docker stop mycontainer
+docker build -t python3.10.8_with_mecab .
+docker build -t app_deploy .
+if [ -n "$(echo `docker ps -a | grep rss_api`)" ]; then
+    docker stop rss_api
+    docker rm rss_api
 fi
-docker run -d --rm --name mycontainer -p 8000:8000 deployimg 
+docker run -it -d --name rss_api -p 8000:8000 --add-host=gateway.docker.internal:host-gateway app_deploy

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -5,13 +5,13 @@ services:
     image: postgres:latest
     restart: always
     environment:
-      POSTGRES_USER: cacaomath
-      POSTGRES_PASSWORD: password
-      PGPASSWORD: password123
-      POSTGRES_DB: sample
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      PGPASSWORD: $PGPASSWORD
+      POSTGRES_DB: $POSTGRES_DB
       TZ: "Asia/Tokyo"
     ports:
-      - 5432:5432
+      - ${POSTGRES_SERVER_PORT:-5432}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 

--- a/dockerfile/neologd/Dockerfile
+++ b/dockerfile/neologd/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10.8-slim
+
+RUN apt update \
+    && apt install -y sudo mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils file \
+    && cd /tmp/ \
+    && git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git \
+    && cd mecab-ipadic-neologd \
+    && echo yes | ./bin/install-mecab-ipadic-neologd -n
+
+

--- a/img_setup.sh
+++ b/img_setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-apt update
-apt install -y mecab libmecab-dev mecab-ipadic-utf8
-pip install --upgrade pip
-pip install fastapi uvicorn
-pip install pipenv
-pipenv install


### PR DESCRIPTION
アプリをデプロイするためのDocker imageの整理
今まで辞書はホストにインストールしたが、imageとして固めておくことで
煩雑さをなくす